### PR TITLE
Add option to define a custom tagName for the element returned

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ const text = 'Foo http://google.com bar http:/twitter.com baz http//google.com'
 const options = {className: 'foo'}
 <ReactAutolinker text={text} options={options} />
 
+// With custom tag name for the component (default is div)
+<ReactAutolinker text={text} tagName='p' />
+
 // Custom per link render (default implementation shown)
 const renderLink = (tag) => React.createElement(tag.tagName, tag.attrs, tag.innerHtml)
 <ReactAutolinker text={text} renderLink={renderLink} />

--- a/src/index.js
+++ b/src/index.js
@@ -5,15 +5,17 @@ import PropTypes from "prop-types";
 export default class ReactAutolinker extends React.Component {
   static propTypes = {
     options: PropTypes.object,
-    renderLink: PropTypes.func
+    renderLink: PropTypes.func,
+    tagName: PropTypes.string
   };
   static defaultProps = {
     options: {},
     renderLink: tag =>
-      React.createElement(tag.tagName, tag.attrs, tag.innerHtml)
+      React.createElement(tag.tagName, tag.attrs, tag.innerHtml),
+    tagName: 'div'
   };
   render() {
-    const { options, text, renderLink } = this.props;
+    const { options, text, renderLink, tagName } = this.props;
 
     const tags = [];
     Autolinker.link(text, {
@@ -44,9 +46,9 @@ export default class ReactAutolinker extends React.Component {
 
     const content = children.length ? children : text;
     const props = { ...this.props };
-    for (let prop of ["text", "options", "renderLink"]) {
+    for (let prop of ["text", "options", "renderLink", "tagName"]) {
       delete props[prop];
     }
-    return React.createElement("div", props, content);
+    return React.createElement(tagName, props, content);
   }
 }


### PR DESCRIPTION
By default the returned element is a `<div>`. 

I think it would be nice if we would be able to change it to `<p>` for example.