### PR TITLE
allow text after the last link

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -43,12 +43,12 @@ export default class ReactAutolinker extends React.Component {
       children.push(renderLink(tag));
       _text = parts.join(tag.attrs.href);
     }
+    children.push(_text);
 
-    const content = children.length ? children : text;
     const props = { ...this.props };
     for (let prop of ["text", "options", "renderLink", "tagName"]) {
       delete props[prop];
     }
-    return React.createElement(tagName, props, content);
+    return React.createElement(tagName, props, children);
   }
 }


### PR DESCRIPTION
Right now, any text after the last link is not displayed. This PR fixes that.

I had a few problems working w/ this. I had to vendor the dep because the babel-config didn't work with parcel, but that's a separate story. I might open up PRs for that as well.

Thanks for the project!