### PR TITLE
Avoid text split bug by using matchedText

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,7 @@ export default class ReactAutolinker extends React.Component {
       ...options,
       replaceFn: (autolinker, match) => {
         const tag = autolinker.getTagBuilder().build(match);
+        tag.matchedText = match.matchedText;
         tags.push(tag);
         return tag;
       }
@@ -30,9 +31,8 @@ export default class ReactAutolinker extends React.Component {
     let _text = text;
     const children = [];
     for (let tag of tags) {
-      const splitText = _text.includes(tag.attrs.href)
-        ? tag.attrs.href
-        : tag.innerHtml;
+      const splitText = tag.matchedText;
+
       const parts = _text.split(splitText);
       if (tag.attrs && tag.attrs.class) {
         tag.attrs.className = tag.attrs.class;
@@ -41,7 +41,7 @@ export default class ReactAutolinker extends React.Component {
       tag.attrs.key = `${tag.attrs.href}-${tags.indexOf(tag)}`;
       children.push(parts.shift());
       children.push(renderLink(tag));
-      _text = parts.join(tag.attrs.href);
+      _text = parts.join(tag.matchedText);
     }
     children.push(_text);
 


### PR DESCRIPTION
It's been ages till #5 was posted, but today I have faced exactly the same issue. It seems that the `www.google.com` string is causing everything to break, as `tag.attrs.href` and `tag.innerHtml` aren't good matchers for this case.

I have tested it with such long text and without the changes it was rendered like on the first screenshot, on the second screenshot version after fix:
```
- Visit google.com for your search needs.
- Just www.google.com
- You can also use https://google.com if you prefer a secure connection.
- Alternatively, http://www.google.com works as well.
- Don’t forget about www.google.co.uk for the UK-specific site.
- Here's a fun site: http://example.org.
- For your info, check out https://subdomain.example.net/page.
- Need a secure link? Try https://secure-site.com.
- You can reach out via email: jan@example.com.
- Another email option: support@my-site.org.
- Feel free to call at (123) 456-7890.
- International number? +44 20 7946 0958 is what you need.
- Check ftp://ftp.example.com for the FTP site.
- For more information, try mailto:info@company.com.
```

![image](https://github.com/user-attachments/assets/91156f6e-df43-41ab-be56-39dc6aa94b7a)
![image](https://github.com/user-attachments/assets/0321c4b1-0d34-429c-af28-737cf5d2d80e)
(The last example with `mailto` is my presentation mistake, it's correctly rendered after removing additional `mailto:` text)
